### PR TITLE
chore: add cost estimate to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,39 @@ provider "aws" {
 
 *To view sensitive secret, try `terraform output secret_access_key`*
 
+## Cost Estimate
+
+This cost estimate is based on **on-demand** pricing. AWS offers free tiers for some of these resources, which may reduce or eliminate costs for small-scale or new users.
+
+Assuming 1,000 unique IPs traffic daily with the assumption of 1MB as page size, we'll have 30,000 Requests monthly and 30GB data transfer. Here's how the estimated breakdown will look like:
+
+### S3
+- **Storage**: $0.023/GB (Standard Storage) (Assuming our app is 100MB) = $0.0023 (Pretty low)
+- **Request**: GET $0.0004 per 1,000 requests. 30,000 will be $0.012
+- **Data Transfer**: Too low - CloudFront caching
+
+### CloudFront
+- **Data Transfer**: $0.085 per GB for the first 10TB = $0.085 * 30 = $2.55
+- **Request**: $0.0075 per 10,000 HTTP/HTTPS requests. 30,000 will be $0.0225
+
+### WAF
+- **WebACL**: $5 per WebACL
+- **Rule**: $1 per rule per WebACL. Assuming 10 rules, the cost will be $10
+- **Requests**: $0.60 per 1 million requests. 30,000 requests will be $0.018
+
+The total cost will be approximately **$2.586** for S3 and CloudFront, and $15.018 for WAF, making the grand total approximately $17.604.
+
+Please note that these are just estimates. The actual cost may vary depending on the usage, data transfer, and number of requests. Also, this doesn't include potential costs for Route53, ACM, and other AWS services that might be used.
+
+This changes drastically for 100M visits daily or weekly but latency will still be guaranteed.
+
+This estimation serves as a rough guide. Actual costs may vary based on several factors, including the geographic distribution of requests, the size of the objects being requested, caching efficiency, and any applicable discounts or reserved pricing.
+
+It’s important to employ strategies to minimize costs, such as optimizing content delivery, using budget alarms, employing efficient caching, and regularly reviewing usage patterns.
+
+AWS offers a [pricing calculator](https://calculator.aws/#/) to provide more precise and tailored cost estimations, considering specific details and configurations of your static site deployment.
+
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.


### PR DESCRIPTION
This pull request includes a significant update to the `README.md` file. The change adds a detailed cost estimate section that breaks down the potential costs of using various AWS services, such as S3, CloudFront, and WAF, for a hypothetical scenario of 1,000 unique IP traffic daily. The added section also provides guidance on cost minimization strategies and a link to AWS's pricing calculator for more tailored cost estimations.

Key Changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R89-R121): Added a comprehensive cost estimate section, detailing the potential costs of using AWS services for a specific usage scenario. The section also includes cost minimization strategies and a link to AWS's pricing calculator for more precise cost estimations.